### PR TITLE
Fix schema name for logging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Assuming your interfaces you want olsrd2 to listen on are ``eth0, wlan0 and lo``
 
 You won't see much output though. You can enable more output (by default it comes on stderr) for several subsystems. You can get a list of these subsystems with:
 
-  * ``./olsrd2_static --schema=log.info``
-  * ``./olsrd2_static --schema=log.debug``
+  * ``./olsrd2_static --schema=logging.info``
+  * ``./olsrd2_static --schema=logging.debug``
 
 This shows you which info and debug schemas exist. Let's say we are interested in the neighborhood disovery protocol (NHDP, RFC6130, "Hello messages"). We can set this subsystem writing actions to debug level via:
 


### PR DESCRIPTION
I noticed the following in v0.15.1:

```
root@AP-2-76:~# olsrd2 --schema=log.info
    info (list)
    Default value:
    Parameter must be on of the following list:
    'all', 'main', 'logging', 'config', 'plugins', 'subsystems', 'class', 'clock', 'duplicate_set', 'eth_listener', 'ff_dat_metric', 'ff_dat_metric_raw', 'layer2', 'layer2info', 'link_config', 'neighbor_probing', 'netjsoninfo', 'nhdp', 'nhdp_r', 'nhdp_w', 'nhdpinfo', 'nl80211_listener', 'olsrv2', 'olsrv2_r', 'olsrv2_w', 'olsrv2_routing', 'olsrv2info', 'os_fd', 'os_interface', 'os_routing', 'os_system', 'packet_socket', 'rfc5444', 'socket', 'stream_socket', 'systeminfo', 'telnet', 'timer', 'viewer', 'rfc5444_r', 'rfc5444_w'
    Description:
        Set logging sources that display info and warnings
root@AP-2-76:~# olsrd2 --schema=logging.info
```

Thus the documentation is probably not correct at the moment.