### PR TITLE
Added missing "extern" to declarations:

### DIFF
--- a/include/oonf/generic/dlep/dlep_internal.h
+++ b/include/oonf/generic/dlep/dlep_internal.h
@@ -49,13 +49,13 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the generic DLEP code */
-enum oonf_log_source LOG_DLEP;
+extern enum oonf_log_source LOG_DLEP;
 
 /* headers only for use inside the DLEP_RADIO code*/
-enum oonf_log_source LOG_DLEP_RADIO;
+extern enum oonf_log_source LOG_DLEP_RADIO;
 
 /* headers only for use inside the DLEP_ROUTER code*/
-enum oonf_log_source LOG_DLEP_ROUTER;
+extern enum oonf_log_source LOG_DLEP_ROUTER;
 
 #endif /* DLEP_INTERNAL_H_ */
 

--- a/include/oonf/generic/nl80211_listener/nl80211_internal.h
+++ b/include/oonf/generic/nl80211_listener/nl80211_internal.h
@@ -49,6 +49,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the NL80211 subsystem */
-enum oonf_log_source LOG_NL80211;
+extern enum oonf_log_source LOG_NL80211;
 
 #endif /* NL80211_INTERNAL_H_ */

--- a/include/oonf/nhdp/mpr/mpr_internal.h
+++ b/include/oonf/nhdp/mpr/mpr_internal.h
@@ -48,6 +48,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the MPR subsystem */
-enum oonf_log_source LOG_MPR;
+extern enum oonf_log_source LOG_MPR;
 
 #endif /* MPR_INTERNAL_H_ */

--- a/include/oonf/nhdp/nhdp/nhdp_internal.h
+++ b/include/oonf/nhdp/nhdp/nhdp_internal.h
@@ -49,8 +49,8 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the NHDP subsystem */
-enum oonf_log_source LOG_NHDP;
-enum oonf_log_source LOG_NHDP_R;
-enum oonf_log_source LOG_NHDP_W;
+extern enum oonf_log_source LOG_NHDP;
+extern enum oonf_log_source LOG_NHDP_R;
+extern enum oonf_log_source LOG_NHDP_W;
 
 #endif /* NHDP_INTERNAL_H_ */

--- a/include/oonf/olsrv2/olsrv2/olsrv2_internal.h
+++ b/include/oonf/olsrv2/olsrv2/olsrv2_internal.h
@@ -50,9 +50,9 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the OLSRv2 subsystem */
-EXPORT enum oonf_log_source LOG_OLSRV2;
-EXPORT enum oonf_log_source LOG_OLSRV2_R;
-EXPORT enum oonf_log_source LOG_OLSRV2_ROUTING;
-EXPORT enum oonf_log_source LOG_OLSRV2_W;
+EXPORT extern enum oonf_log_source LOG_OLSRV2;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_R;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_ROUTING;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_W;
 
 #endif /* OLSRV2_INTERNAL_H_ */


### PR DESCRIPTION
**LOG_DLEP_RADIO** in dlep_internal.h
**LOG_NL80211** in nl80211_internal.h
**LOG_MPR** in mpr_internal.h
**LOG_NHDP**, **LOG_NHDP_R**, **LOG_NHDP_W** in nhdp_internal.h
**LOG_OLSRV2**, **LOG_OLSRV2_R**, **LOG_OLSRV2_ROUTING**, **LOG_OLSRV2_W** in olsrv2_internal.h

These caused symbol conflicts in GCC 10 as well as in GCC <10 when linking with '-fno-common'.
(see issue #28)
