### PR TITLE
ignore not yet implemented TLV 20

### DIFF
--- a/src/generic/dlep/dlep_session.c
+++ b/src/generic/dlep/dlep_session.c
@@ -919,6 +919,13 @@ _parse_tlvstream(struct dlep_session *session, const uint8_t *buffer, size_t len
       return DLEP_NEW_PARSER_INCOMPLETE_TLV;
     }
 
+    /* if TLV=20, we'll ignore it */
+    if (tlv_type == 20) {
+      OONF_WARN(session->log_source, "ignore unsupported TLV 20");
+      idx += tlv_length;
+      continue;
+    }
+
     /* check if tlv is supported */
     tlv = dlep_parser_get_tlv(parser, tlv_type);
     if (!tlv) {


### PR DESCRIPTION
workaround to handle incoming DLEP messages with TLV 20 (MTU) by ignoring this optional data item without resulting in a session termination