### PR TITLE
peer update fix for MTU TLV

### DIFF
--- a/src/generic/dlep/ext_base_metric/metric.c
+++ b/src/generic/dlep/ext_base_metric/metric.c
@@ -85,6 +85,7 @@ static const uint16_t _peer_update_tlvs[] = {
   DLEP_RESOURCES_TLV,
   DLEP_RLQR_TLV,
   DLEP_RLQT_TLV,
+  DLEP_MTU_TLV,
 };
 
 /* destination up/update */


### PR DESCRIPTION
proposed fix by HRogge to avoid errors in PeerUpdate when receiving TLV 20 (MTU)