### PR TITLE
fix build for gcc-10 (-fno-common default)

### DIFF
--- a/include/oonf/generic/dlep/radio/dlep_radio_internal.h
+++ b/include/oonf/generic/dlep/radio/dlep_radio_internal.h
@@ -49,6 +49,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the DLEP_RADIO subsystem */
-enum oonf_log_source LOG_DLEP_RADIO;
+extern enum oonf_log_source LOG_DLEP_RADIO;
 
 #endif /* DLEP_RADIO_INTERNAL_H_ */

--- a/include/oonf/generic/dlep/router/dlep_router_internal.h
+++ b/include/oonf/generic/dlep/router/dlep_router_internal.h
@@ -49,6 +49,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the DLEP_ROUTER subsystem */
-enum oonf_log_source LOG_DLEP_ROUTER;
+extern enum oonf_log_source LOG_DLEP_ROUTER;
 
 #endif /* DLEP_ROUTER_INTERNAL_H_ */

--- a/include/oonf/libcommon/netaddr.h
+++ b/include/oonf/libcommon/netaddr.h
@@ -172,8 +172,8 @@ EXPORT extern const struct netaddr NETADDR_IPV6_IPV4COMPATIBLE;
 EXPORT extern const struct netaddr NETADDR_IPV6_IPV4MAPPED;
 EXPORT extern const struct netaddr NETADDR_IPV6_LOOPBACK;
 EXPORT extern const struct netaddr NETADDR_MAC48_BROADCAST;
-EXPORT const struct netaddr NETADDR_MAC48_IPV4_MULTICAST;
-EXPORT const struct netaddr NETADDR_MAC48_IPV6_MULTICAST;
+EXPORT extern const struct netaddr NETADDR_MAC48_IPV4_MULTICAST;
+EXPORT extern const struct netaddr NETADDR_MAC48_IPV6_MULTICAST;
 
 EXPORT extern const union netaddr_socket NETADDR_SOCKET_IPV4_ANY;
 EXPORT extern const union netaddr_socket NETADDR_SOCKET_IPV6_ANY;

--- a/include/oonf/nhdp/mpr/mpr_internal.h
+++ b/include/oonf/nhdp/mpr/mpr_internal.h
@@ -48,6 +48,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the MPR subsystem */
-enum oonf_log_source LOG_MPR;
+extern enum oonf_log_source LOG_MPR;
 
 #endif /* MPR_INTERNAL_H_ */

--- a/include/oonf/nhdp/nhdp/nhdp_internal.h
+++ b/include/oonf/nhdp/nhdp/nhdp_internal.h
@@ -49,8 +49,8 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the NHDP subsystem */
-enum oonf_log_source LOG_NHDP;
-enum oonf_log_source LOG_NHDP_R;
-enum oonf_log_source LOG_NHDP_W;
+extern enum oonf_log_source LOG_NHDP;
+extern enum oonf_log_source LOG_NHDP_R;
+extern enum oonf_log_source LOG_NHDP_W;
 
 #endif /* NHDP_INTERNAL_H_ */

--- a/include/oonf/olsrv2/olsrv2/olsrv2_internal.h
+++ b/include/oonf/olsrv2/olsrv2/olsrv2_internal.h
@@ -50,9 +50,9 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the OLSRv2 subsystem */
-EXPORT enum oonf_log_source LOG_OLSRV2;
-EXPORT enum oonf_log_source LOG_OLSRV2_R;
-EXPORT enum oonf_log_source LOG_OLSRV2_ROUTING;
-EXPORT enum oonf_log_source LOG_OLSRV2_W;
+EXPORT extern enum oonf_log_source LOG_OLSRV2;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_R;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_ROUTING;
+EXPORT extern enum oonf_log_source LOG_OLSRV2_W;
 
 #endif /* OLSRV2_INTERNAL_H_ */


### PR DESCRIPTION
https://gcc.gnu.org/gcc-10/porting_to.html enabled -fno-common
by default which uncovered multiple definitions in oonf:

    ld: CMakeFiles/oonf_dlep_proxy.dir/router/dlep_router_session.c.o:(.bss+0x0):
      multiple definition of `LOG_DLEP_ROUTER'; CMakeFiles/oonf_dlep_proxy.dir/router/dlep_router.c.o:(.bss+0x0): first defined here

The change turns all definitions in headers into declarations.