### PR TITLE
add missing extern to global symbol

### DIFF
--- a/include/oonf/generic/nl80211_listener/nl80211_internal.h
+++ b/include/oonf/generic/nl80211_listener/nl80211_internal.h
@@ -49,6 +49,6 @@
 #include <oonf/libcore/oonf_logging.h>
 
 /* headers only for use inside the NL80211 subsystem */
-enum oonf_log_source LOG_NL80211;
+extern enum oonf_log_source LOG_NL80211;
 
 #endif /* NL80211_INTERNAL_H_ */


### PR DESCRIPTION
the nl80211_listener plugin is affected by issue #40