### PR TITLE
the package dh-systemd is not longer present in recent Ubuntu versions

### DIFF
--- a/apps/olsrd2/debian/control
+++ b/apps/olsrd2/debian/control
@@ -3,7 +3,7 @@ Maintainer: Henning Rogge <henning.rogge@fkie.fraunhofer.de>
 Section: net
 Priority: optional
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9), dh-systemd (>= 1.5)
+Build-Depends: debhelper (>= 9)
 
 Package: olsrd2
 Architecture: any


### PR DESCRIPTION
dh-systemd is also marked as a transitional package:  This package is for transitional purposes and can be removed safely.