### PR TITLE
Lan import name collision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /doxygen_sqlite3.db
 /doxygen_objdb_*.tmp
 /doxygen_entrydb_*.tmp
+.vscode/

--- a/src/olsrv2/lan_import/lan_import.c
+++ b/src/olsrv2/lan_import/lan_import.c
@@ -64,7 +64,7 @@
 #include <oonf/olsrv2/lan_import/lan_import.h>
 
 /* definitions */
-#define LOG_LAN_IMPORT _import_subsystem.logging
+#define LOG_LAN_IMPORT _olsrv2_lan_import_subsystem.logging
 
 /**
  * configuration of one LAN import instance
@@ -195,7 +195,7 @@ static const char *_dependencies[] = {
   OONF_OLSRV2_SUBSYSTEM,
   OONF_OS_ROUTING_SUBSYSTEM,
 };
-static struct oonf_subsystem _import_subsystem = {
+static struct oonf_subsystem _olsrv2_lan_import_subsystem = {
   .name = OONF_LAN_IMPORT_SUBSYSTEM,
   .dependencies = _dependencies,
   .dependencies_count = ARRAYSIZE(_dependencies),
@@ -208,7 +208,7 @@ static struct oonf_subsystem _import_subsystem = {
   .cleanup = _cleanup,
   .initiate_shutdown = _initiate_shutdown,
 };
-DECLARE_OONF_PLUGIN(_import_subsystem);
+DECLARE_OONF_PLUGIN(_olsrv2_lan_import_subsystem);
 
 /* class definition for filters */
 static struct oonf_class _import_class = {


### PR DESCRIPTION
As it stands, both, the lan_import and the layer2_import use the same symbol to install the subsystem. The proposed patch renames the plugin instance in lan_import from _import_subsystem to _olsrv2_lan_import_subsystem