### PR TITLE
Fix DLEP Router TCP Session Interface

### DIFF
--- a/include/oonf/generic/dlep/dlep_session.h
+++ b/include/oonf/generic/dlep/dlep_session.h
@@ -356,6 +356,9 @@ struct dlep_session {
 
   /*! remember all streams bound to an interface */
   struct avl_node _node;
+
+  /*! interface index of the interface, the DLEP offer came from */
+  unsigned dlep_if_index;
 };
 
 void dlep_session_init(void);

--- a/openwrt/oonf-dlep-proxy-git-debug/Makefile
+++ b/openwrt/oonf-dlep-proxy-git-debug/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONS=-D OONF_NO_WERROR:Bool=true \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_proxy" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_proxy" \
               -D INSTALL_LIB_DIR:Path=lib/oonf \
               -D INSTALL_INCLUDE_DIR:Path=include/oonf \
               -D INSTALL_CMAKE_DIR:Path=lib/oonf \

--- a/openwrt/oonf-dlep-proxy-git/Makefile
+++ b/openwrt/oonf-dlep-proxy-git/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONS=-D OONF_NO_WERROR:Bool=true \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_proxy" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_proxy" \
               -D INSTALL_LIB_DIR:Path=lib/oonf \
               -D INSTALL_INCLUDE_DIR:Path=include/oonf \
               -D INSTALL_CMAKE_DIR:Path=lib/oonf \

--- a/openwrt/oonf-dlep-radio-git-debug/Makefile
+++ b/openwrt/oonf-dlep-radio-git-debug/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONS=-D OONF_NO_WERROR:Bool=true \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_radio" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep" \
               -D INSTALL_LIB_DIR:Path=lib/oonf \
               -D INSTALL_INCLUDE_DIR:Path=include/oonf \
               -D INSTALL_CMAKE_DIR:Path=lib/oonf \

--- a/openwrt/oonf-dlep-radio-git/Makefile
+++ b/openwrt/oonf-dlep-radio-git/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONS=-D OONF_NO_WERROR:Bool=true \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep_radio" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;layer2;packet_socket;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_system;nl80211_listener;layer2info;systeminfo;cfg_uciloader;cfg_compact;dlep" \
               -D INSTALL_LIB_DIR:Path=lib/oonf \
               -D INSTALL_INCLUDE_DIR:Path=include/oonf \
               -D INSTALL_CMAKE_DIR:Path=lib/oonf \

--- a/openwrt/oonf-olsrd2-git-debug/Makefile
+++ b/openwrt/oonf-olsrd2-git-debug/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONAL_PLUGINS:= $(subst $(SPACE),;,$(strip \
         $(if $(filter y,$(CONFIG_OONF_NHDP_AUTOLL4)),auto_ll4,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN_IMPORT)),lan_import,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_ROUTE_MODIFIER)),route_modifier,) \
-        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep_router,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_REMOTECONTROL)),remotecontrol,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_MPR)),mpr,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_HTTP)),http,) \
@@ -29,7 +29,7 @@ CMAKE_OPTIONS=-D CMAKE_BUILD_TYPE:String=Debug \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
               -D OONF_LIB_GIT:String=v$(PKG_VERSION)-archive \
               -D OONF_VERSION:String=$(PKG_VERSION) \
               -D INSTALL_LIB_DIR:Path=lib/oonf \

--- a/openwrt/oonf-olsrd2-git/Makefile
+++ b/openwrt/oonf-olsrd2-git/Makefile
@@ -14,7 +14,7 @@ CMAKE_OPTIONAL_PLUGINS:= $(subst $(SPACE),;,$(strip \
         $(if $(filter y,$(CONFIG_OONF_NHDP_AUTOLL4)),auto_ll4,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_LAN_IMPORT)),lan_import,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_ROUTE_MODIFIER)),route_modifier,) \
-        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep_router,) \
+        $(if $(filter y,$(CONFIG_OONF_GENERIC_DLEP_ROUTER)),dlep,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_REMOTECONTROL)),remotecontrol,) \
         $(if $(filter y,$(CONFIG_OONF_OLSRV2_MPR)),mpr,) \
         $(if $(filter y,$(CONFIG_OONF_GENERIC_HTTP)),http,) \
@@ -31,7 +31,7 @@ CMAKE_OPTIONS=-D CMAKE_BUILD_TYPE:String=$(BUILD_TYPE) \
               -D OONF_NO_TESTING:Bool=true \
               -D UCI:Bool=true \
               -D OONF_APP_DEFAULT_CFG_HANDLER:String=uci \
-              -D OONF_STATIC_PLUGINS:String="class;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
+              -D OONF_STATIC_PLUGINS:String="class;callback;clock;duplicate_set;layer2;packet_socket;rfc5444;socket;stream_socket;telnet;timer;viewer;os_clock;os_fd;os_interface;os_routing;os_system;nhdp;olsrv2;ff_dat_metric;neighbor_probing;nl80211_listener;link_config;layer2info;systeminfo;cfg_uciloader;cfg_compact;nhdpinfo;olsrv2info;netjsoninfo;${CMAKE_OPTIONAL_PLUGINS}" \
               -D OONF_LIB_GIT:String=v$(PKG_VERSION)-archive \
               -D OONF_VERSION:String=$(PKG_VERSION) \
               -D INSTALL_LIB_DIR:Path=lib/oonf \

--- a/src/generic/dlep/dlep_interface.c
+++ b/src/generic/dlep/dlep_interface.c
@@ -224,6 +224,9 @@ _cb_receive_udp(struct oonf_packet_socket *pkt, union netaddr_socket *from, void
   /* copy socket information */
   memcpy(&interf->session.remote_socket, from, sizeof(interf->session.remote_socket));
 
+  /* save the interface index of the interface, the DLEP session offer came from */
+  interf->session.dlep_if_index = pkt->os_if->index;
+
   processed = dlep_session_process_buffer(&interf->session, buffer, length, true);
   if (processed < 0) {
     /* Session is now most likely invalid */

--- a/src/generic/dlep/ext_base_proto/proto_router.c
+++ b/src/generic/dlep/ext_base_proto/proto_router.c
@@ -288,7 +288,7 @@ _router_process_peer_offer(struct dlep_extension *ext __attribute__((unused)), s
       ip = os_interface_get_prefix_from_dst(&addr, ifdata);
       if (ip) {
         result = &ip->address;
-        netaddr_socket_init(&remote, &addr, port, ifdata->index);
+        netaddr_socket_init(&remote, &addr, port, session->dlep_if_index);
       }
     }
     value = dlep_session_get_next_tlv_value(session, value);
@@ -308,7 +308,7 @@ _router_process_peer_offer(struct dlep_extension *ext __attribute__((unused)), s
       ip = os_interface_get_prefix_from_dst(&addr, ifdata);
       if (ip) {
         result = &ip->address;
-        netaddr_socket_init(&remote, &addr, port, ifdata->index);
+        netaddr_socket_init(&remote, &addr, port, session->dlep_if_index);
       }
     }
     value = dlep_session_get_next_tlv_value(session, value);
@@ -324,11 +324,11 @@ _router_process_peer_offer(struct dlep_extension *ext __attribute__((unused)), s
       return DLEP_NEW_PARSER_INTERNAL_ERROR;
     }
     result = &ip->address;
-    netaddr_socket_init(&remote, &addr, port, ifdata->index);
+    netaddr_socket_init(&remote, &addr, port, session->dlep_if_index);
   }
 
   /* initialize session */
-  netaddr_socket_init(&local, result, 0, ifdata->index);
+  netaddr_socket_init(&local, result, 0, session->dlep_if_index);
 
   router_if = dlep_router_get_by_layer2_if(ifdata->name);
   if (router_if && &router_if->interf.session == session) {


### PR DESCRIPTION
Previously, DLEP router would always chose the "main" inteface when trying to establish a DLEP TCP session, even if an out of band datapath interface is specified.
This PR changes the behaviour to use the same interface for the TCP connection that the discovery offer was received on.


This is tested to be working on OpenWrt 22.03.0 with the following configs (eth3 is the interface on the router, eth0 is the interface on the wifi device. VLAN 254 is used for DLEP with only IPv6 LL addresses and VLAN 255 is used for the actual data):

`/etc/config/olsrd2` on the router:
```
config global
	option 'failfast'	'no'
	option 'pidfile'	'/var/run/olsrd2.pid'
	option 'lockfile'	'/var/lock/olsrd2'

config log
	option 'syslog'		'true'
	option 'stderr'		'true'
#	option 'debug'		'dlep_router'

config telnet
	option 'port' '2009'

config olsrv2
	list 'originator' '-fe80::/112'
	list 'originator' '-2a02:61:0:ee:1::0/80'
	list 'originator' '-2a02:60::0/32'
	list 'originator' '-0.0.0.0/0'
	list 'originator' '-::1/128'
	list 'originator' 'default_accept'

config interface
	option 'ifname' 'loopback'
	list 'bindto' '-0.0.0.0/0'
	list 'bindto' '-::1/128'
	list 'bindto' 'default_accept'

config interface
	option 'ifname' '0xff_eth3'
	list 'bindto' '-0.0.0.0/0'
	list 'bindto' '-::1/128'
	list 'bindto' 'default_accept'

config dlep_router
	option 'ifname' '0xff_eth3'
	option 'datapath_if' 'eth3.254'
```

`/etc/config/dlep_radio` on the wifi device:
```
config global
	option 'failfast' 'no'
	option 'pidfile'  '/var/run/dlep_radio.pid'
	option 'lockfile' '/var/lock/dlep_radio'

config log
	option 'syslog'   'true'
	option 'stderr'   'true'

config telnet
	option 'port' '2009'

config dlep_radio
	list   'name'               'wlan0'
	option 'datapath_if'  'eth0.254'
	option 'not_proxied' 'false'
	option 'proxied'        'true'

config nl80211_listener
	option 'if'          'wlan0'
	option 'interval'    '1.0'
```

Also included in this PR are the changes to the OpenWrt Makefiles to reflect the changes between master and develop in terms of plugin configuration.