### PR TITLE
Fix lan_import plugin build

### DIFF
--- a/src/olsrv2/CMakeLists.txt
+++ b/src/olsrv2/CMakeLists.txt
@@ -6,4 +6,5 @@ add_subdirectory(olsrv2_old_lan)
 add_subdirectory(olsrv2_l2import)
 add_subdirectory(olsrv2_lan)
 add_subdirectory(route_modifier)
+add_subdirectory(lan_import)
 


### PR DESCRIPTION
On master a similar fix was merged a while ago, on develop it is also needed.