### PR TITLE
Do not depend on specific networking.service

### DIFF
--- a/apps/olsrd2/debian/olsrd2.service
+++ b/apps/olsrd2/debian/olsrd2.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=OLSRd2 Routing agent
 Documentation=http://www.olsr.org/
-Requires=networking.service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/olsrd2_static --load=/etc/olsrd2/olsrd2.conf


### PR DESCRIPTION
There are several services which can implement network configuration. networking.service is only one of them. When a system does not have networking.service installed but e.g. systemd-networkd then starting OLSRd2 fails.
A better and more general approach is to wait to network being online.