### PR TITLE
Add LICENSE file with the project's BSD-3-Clause terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,36 @@
+The olsr.org Network Framework (OONF)
+Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+* Neither the name of olsr.org, olsrd nor the names of its
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+Visit http://www.olsr.org for more information.
+
+If you find this software useful feel free to make a donation
+to the project. For more information see the website or contact
+the copyright holders.


### PR DESCRIPTION
The source files carry BSD-3-Clause headers, but the repository had no standalone LICENSE file. This adds one reproducing the license text and copyright notice already used in the source headers. It does not change the license.

This helps license scanners, SBOM tooling, and downstream packaging that expects a root-level license file (e.g. OpenWrt's PKG_LICENSE_FILES).

Refs: #76